### PR TITLE
ci(publishing): prevent examples dir from being published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
       - run: npm run test
         working-directory: .
 
+      # Exclude examples from being published
+      - run: rm -rf examples
+
       - run: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests/.builds*
 tmp
 bin
 .generated
+examples/express/node_modules


### PR DESCRIPTION
Fixing semantic release trying to publish entire express example.